### PR TITLE
Fix quoting for map keys

### DIFF
--- a/xlsx2tf.py
+++ b/xlsx2tf.py
@@ -62,6 +62,8 @@ def format_hcl_value(name, val, indent, eqpad="", is_map=False):
     """
     ind = '  ' * indent
     eqpad = eqpad or ''
+    if is_map and not re.fullmatch(r"[0-9A-Za-z_-]+", name):
+        name = f'"{name}"'
     if val is None or val == "" or (isinstance(val, list) and len(val) == 0):
         return ""
     if isinstance(val, str):


### PR DESCRIPTION
## Summary
- quote map keys when they contain special characters in the Python implementation
- revert accidental VBA change

## Testing
- `python - <<'PY'
import types, sys
sys.modules['openpyxl'] = types.SimpleNamespace()
from xlsx2tf import dict_to_resource_hcl
sample = {
    'azurerm_linux_function_app': {
        'res-13': {
            'tags': {
                'hidden-link: /app-insights-conn-string': 'val'
            }
        }
    }
}
print(dict_to_resource_hcl(sample))
PY`
- ❌ `pip install openpyxl`

------
https://chatgpt.com/codex/tasks/task_e_6858445744ac8331802002aa5bca0576